### PR TITLE
WIP Add Bity plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plugins/bity"]
+	path = plugins/bity
+	url = https://github.com/BitySA/airbitz-bity-plugin.git

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ generate bitcoin payment addresses and request spends from the user.
 
 ## Install dependencies
 
+We are using git submodules, so make sure to initialize them on cloning the repo as
+
+    git clone --recurse-submodules https://github.com/Airbitz/airbitz-plugins.git
+
+If you forget to do so, you can do it afterwards with
+
+    git submodule update --init --recursive
+
 Install node on Ubuntu
 
     apt-get install nodejs
@@ -24,7 +32,8 @@ Install node modules
     npm install
 
 Check the available tasks
+
     gulp help
-    
+
 ## API Documentation
 [Airbitz Developer Website](https://developer.airbitz.co/plugins)


### PR DESCRIPTION
**Still work in progress.**

I'm adding our Bity plugin relying on `git-submodule` rather than copying the whole codebase. I think this is a much cleaner way to pull code from other repos. As you can see [here](https://github.com/BitySA/airbitz-plugins/tree/master/plugins), GitHub renders the `bity` directory differently, and the link points to our repo in the exact commit specified in `.gitmodules`.

@paullinator, you proposed using `npm` for this, but I'm not sure how to make it behave like `git-submodule`. In any case, that solution would not integrate as nicely with GitHub.

The only drawback of this solution is that submodules are not initialized automatically on `git clone`, so I have updated `README.md` to reflect how to properly do it. This adds another step, which might be what you were trying to avoid, but there is an `npm` [module](https://www.npmjs.com/package/gulp-git-submodule) that could take care of it automatically. I haven't tested it myself, but could take a look into it if you are interested in going this way.